### PR TITLE
fix: double semicolon

### DIFF
--- a/nrgcp.proto
+++ b/nrgcp.proto
@@ -136,7 +136,7 @@ message Nrgcp {
 // NrgcpRequestRejectedPayload
 message NrgcpRequestRejectedPayload {
     int32 code = 2;
-    string name = 1;;
+    string name = 1;
 }
 
 // NrgcpChargecontrolChargevaluesGetPayload


### PR DESCRIPTION
This typo prevents [protobuf.js](https://github.com/protobufjs/protobuf.js) from parsing your definitions. Removing the double semicolon fixes this issue.

Thanks for your great work!